### PR TITLE
Fix path to ~/.s3cfg

### DIFF
--- a/docs/object.rst
+++ b/docs/object.rst
@@ -93,7 +93,7 @@ Install s3cmd:
 
     # yum install s3cmd
 
-and create a config file :file:`~.s3cfg`
+and create a config file :file:`~/.s3cfg`
 
 .. code-block:: bash
 


### PR DESCRIPTION
This looks like a typo,

If I do

touch ~.s3cfg

ls returns 
```
-rw-r--r--.  1 rocky rocky    5 Jan  3 13:49 '~.s3cfg'
```

in the current dir